### PR TITLE
Add Docker development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,132 @@ The integration creates these entities:
 
 Based on [integration_blueprint](https://github.com/ludeeus/integration_blueprint). See [CONTRIBUTING.md](CONTRIBUTING.md) for setup details.
 
+### Docker development environment
+
+The repository includes a standalone Home Assistant development environment. It
+runs Home Assistant in Docker and loads the integration directly from the local
+working tree. The production integration is not installed through HACS in this
+environment.
+
+Docker and Docker Compose are required.
+
+#### Start Home Assistant
+
+From the repository root, start the development instance:
+
+```bash
+docker compose up -d
+docker compose logs -f homeassistant
+```
+
+Open <http://localhost:8123> and complete the initial Home Assistant setup. The
+Compose configuration uses these mounts:
+
+- `./custom_components` → `/config/custom_components`: the current local source
+  code of the integration
+- `./config` → `/config`: the local Home Assistant configuration and runtime data
+
+The local `config` directory is ignored by Git except for
+`config/configuration.yaml`. Training data, the recorder database and Home
+Assistant-generated files therefore stay local.
+
+#### Configure the test integration
+
+The development configuration creates these test entities:
+
+| Purpose | Entity |
+| --- | --- |
+| Prediction target | `input_boolean.test_prediction_target` |
+| Motion feature | `input_boolean.test_motion` |
+| Presence feature | `input_boolean.test_presence` |
+| Simulated hour | `input_number.test_hour` |
+| Ambient light | `input_number.test_ambient_lux` |
+
+In Home Assistant, go to **Settings → Devices & services → Add integration** and
+add **HA Predictions**. Configure it as follows:
+
+- **Target Entity:** `input_boolean.test_prediction_target`
+- **Feature Entities:** `input_boolean.test_motion`, `input_boolean.test_presence`,
+  `input_number.test_hour`, and `input_number.test_ambient_lux`
+
+Changing the feature entities resets the training data. Keep the operation mode on
+`TRAINING` while collecting data. For a first run, select `None` as the sampling
+strategy so that the raw dataset can be inspected without resampling.
+
+#### Generate realistic test data
+
+The repository contains a reproducible test-data generator. It uses the Home
+Assistant REST API to change the test entities, so the integration processes the
+data exactly like normal state changes.
+
+Create a Long-Lived Access Token in your Home Assistant user profile. Do not commit
+the token or put it into a configuration file. Run the generator locally with:
+
+```bash
+python3 scripts/generate_training_data.py --token YOUR_TOKEN
+```
+
+By default, it creates 180 simulated situations across several days. Each situation
+varies the hour, presence, motion and ambient light. The target is derived from
+these values with a small amount of noise to resemble real household data. Because
+each situation changes several Home Assistant entities, the integration usually
+collects several hundred dataset rows.
+
+Useful options:
+
+```bash
+python3 scripts/generate_training_data.py \
+  --token YOUR_TOKEN \
+  --samples 500 \
+  --seed 123 \
+  --delay 0.05
+```
+
+Use `--url` when Home Assistant is not running at `http://localhost:8123`. The
+fixed `--seed` makes a test run reproducible.
+
+#### Train and test predictions
+
+After generating data:
+
+1. Check the **Dataset size** sensor.
+2. Press **Run Training**.
+3. Check **Prediction Performance** and the per-class metrics in its attributes.
+4. Change **Operation Mode** to `PRODUCTION`.
+5. Change the test feature entities and observe **Current Prediction**.
+
+#### Fast development cycle
+
+Python modules are loaded when Home Assistant starts. After changing integration
+code, restart the container to load the new code:
+
+```bash
+docker compose restart homeassistant
+docker compose logs -f homeassistant
+```
+
+Run the standalone tests and code checks from the repository root:
+
+```bash
+scripts/test
+scripts/lint
+```
+
+The existing devcontainer remains available as an alternative. It runs the same
+Home Assistant configuration with `scripts/develop`.
+
+#### Stop or reset the development instance
+
+Stop the instance with:
+
+```bash
+docker compose down
+```
+
+To reset the local Home Assistant state, remove the generated files below `config/`
+while keeping `config/configuration.yaml`. This removes the local HA user, recorder
+history, integration entries and training data.
+
 ## Support
 
 - [Report bugs and request features](https://github.com/nilsreiter/ha-predictions/issues)

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  homeassistant:
+    image: homeassistant/home-assistant:stable
+    container_name: ha-predictions-dev
+    restart: "no"
+    ports:
+      - "8123:8123"
+    environment:
+      TZ: Europe/Berlin
+    volumes:
+      - ./config:/config
+      - ./custom_components:/config/custom_components:ro

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -10,3 +10,29 @@ logger:
   default: warning
   logs:
     custom_components.ha_predictions: debug
+
+# Local development entities for manual integration testing.
+input_boolean:
+  test_prediction_target:
+    name: Test Prediction Target
+    icon: mdi:lightbulb
+  test_motion:
+    name: Test Motion
+    icon: mdi:motion-sensor
+  test_presence:
+    name: Test Presence
+    icon: mdi:account
+
+input_number:
+  test_hour:
+    name: Test Hour
+    min: 0
+    max: 23
+    step: 1
+    mode: box
+  test_ambient_lux:
+    name: Test Ambient Lux
+    min: 0
+    max: 1000
+    step: 1
+    mode: box

--- a/custom_components/ha_predictions/ml/model.py
+++ b/custom_components/ha_predictions/ml/model.py
@@ -310,7 +310,7 @@ class Model:
                     valid = False
                     break
                 try:
-                    if bool(np.isnan(value)):
+                    if not np.isfinite(value):
                         valid = False
                         break
                 except TypeError:

--- a/custom_components/ha_predictions/ml/model.py
+++ b/custom_components/ha_predictions/ml/model.py
@@ -250,10 +250,11 @@ class Model:
         for col_idx in range(data.shape[1]):
             column_data = data[:, col_idx]
 
-            # Check if column contains non-numeric data
-            if column_data.dtype == object or not np.issubdtype(
-                column_data.dtype, np.number
-            ):
+            # Pandas may return a mixed DataFrame as object dtype. Try numeric
+            # conversion per column before treating it as categorical.
+            try:
+                numeric_column = column_data.astype(float)
+            except (TypeError, ValueError):
                 # Use numpy.unique to get unique values and their indices
                 unique_values, inverse_indices = np.unique(
                     column_data, return_inverse=True
@@ -264,7 +265,7 @@ class Model:
                 data_encoded[:, col_idx] = inverse_indices.astype(float)
             else:
                 # Copy numeric data as-is
-                data_encoded[:, col_idx] = column_data.astype(float)
+                data_encoded[:, col_idx] = numeric_column
         return data_encoded, factors
 
     def _apply_filtering(
@@ -298,6 +299,24 @@ class Model:
         if filter_unknown:
             data = data[data[:, -1] != "unknown"]
             data = data[data[:, -1] != "Unknown"]
+
+        # Recorder imports can contain rows before every feature had a value.
+        # Do not pass incomplete mixed-type rows to the encoder.
+        valid_rows = []
+        for row in data:
+            valid = True
+            for value in row:
+                if value is None or value == "":
+                    valid = False
+                    break
+                try:
+                    if bool(np.isnan(value)):
+                        valid = False
+                        break
+                except TypeError:
+                    pass
+            valid_rows.append(valid)
+        data = data[np.array(valid_rows, dtype=bool)]
 
         self.logger.debug("Number of instances after filtering: %i", data.shape[0])
         return data

--- a/scripts/generate_training_data.py
+++ b/scripts/generate_training_data.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Generate realistic test states through the Home Assistant REST API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import time
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+def call_service(base_url: str, token: str, domain: str, service: str, data: dict) -> None:
+    """Call a Home Assistant service."""
+    request = Request(
+        f"{base_url}/api/services/{domain}/{service}",
+        data=json.dumps(data).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urlopen(request, timeout=10) as response:  # noqa: S310
+        if response.status >= 300:
+            raise RuntimeError(f"Home Assistant returned HTTP {response.status}")
+
+
+def set_boolean(base_url: str, token: str, entity_id: str, value: bool) -> None:
+    """Set an input_boolean state."""
+    call_service(
+        base_url,
+        token,
+        "input_boolean",
+        "turn_on" if value else "turn_off",
+        {"entity_id": entity_id},
+    )
+
+
+def set_number(base_url: str, token: str, entity_id: str, value: float) -> None:
+    """Set an input_number state."""
+    call_service(
+        base_url,
+        token,
+        "input_number",
+        "set_value",
+        {"entity_id": entity_id, "value": value},
+    )
+
+
+def generate(args: argparse.Namespace) -> None:
+    """Generate a varied set of household states."""
+    rng = random.Random(args.seed)
+    base_url = args.url.rstrip("/")
+    target_is_on = False
+    set_boolean(base_url, args.token, args.target, False)
+
+    for index in range(args.samples):
+        # Walk through several simulated days instead of repeating one pattern.
+        hour = (index * 3 + rng.randint(-1, 1)) % 24
+        weekday = (index // 24) % 7
+        sleeping = hour < 6 or hour >= 23
+        at_home = not sleeping and rng.random() > (0.25 if weekday < 5 else 0.10)
+        motion = at_home and rng.random() < (0.72 if 7 <= hour < 22 else 0.35)
+
+        # Darkness is higher at night, with weather-like random variation.
+        if sleeping:
+            lux = rng.randint(0, 12)
+        elif 8 <= hour < 18:
+            lux = rng.randint(180, 850)
+        else:
+            lux = rng.randint(15, 220)
+
+        # The target follows a useful pattern, but includes realistic exceptions.
+        should_be_on = at_home and (motion or lux < 55) and not sleeping
+        if rng.random() < 0.08:
+            should_be_on = not should_be_on
+
+        set_number(base_url, args.token, args.hour, hour)
+        set_number(base_url, args.token, args.lux, lux)
+        set_boolean(base_url, args.token, args.presence, at_home)
+        set_boolean(base_url, args.token, args.motion, motion)
+        if should_be_on != target_is_on:
+            set_boolean(base_url, args.token, args.target, should_be_on)
+            target_is_on = should_be_on
+
+        if args.delay:
+            time.sleep(args.delay)
+
+        if (index + 1) % 20 == 0 or index + 1 == args.samples:
+            print(f"Generated {index + 1}/{args.samples} samples")
+
+
+def main() -> None:
+    """Parse command-line arguments and generate data."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--token", required=True, help="Home Assistant long-lived access token")
+    parser.add_argument("--url", default="http://localhost:8123")
+    parser.add_argument("--samples", type=int, default=180)
+    parser.add_argument("--delay", type=float, default=0.05)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--target", default="input_boolean.test_prediction_target")
+    parser.add_argument("--motion", default="input_boolean.test_motion")
+    parser.add_argument("--presence", default="input_boolean.test_presence")
+    parser.add_argument("--hour", default="input_number.test_hour")
+    parser.add_argument("--lux", default="input_number.test_ambient_lux")
+    args = parser.parse_args()
+
+    try:
+        generate(args)
+    except (HTTPError, URLError) as error:
+        raise SystemExit(f"Could not reach Home Assistant: {error}") from error
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add a Docker Compose Home Assistant development environment that mounts the local integration source directly.
- Add local test entities and a reproducible REST-based generator for realistic training data.
- Document setup, configuration, training, testing, and the fast edit/restart workflow.
- Make model preprocessing robust against incomplete recorder rows and mixed numeric/categorical data.

## Why

This gives contributors a fast, isolated way to run and test HA Predictions against a real Home Assistant instance without installing the production integration through HACS. Reproducible test data makes model and integration changes easier to validate consistently.

## Validation

- `docker compose config` passed.
- `git diff --check` passed.
- The pytest suite was not run because `pytest` is not installed in the local environment.